### PR TITLE
[PENG-1356] Specify Python and package dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3-slim AS builder
+FROM python:3.12.5-slim AS builder
 
 ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app requests
-RUN pip install --target=/app importlib-metadata
+RUN pip install --target=/app importlib-metadata==8.4.0
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
 RUN pip3 install --target=/app requests
-#RUN pip install --target=/app importlib-metadata==8.4.0
+RUN pip3 install --target=/app importlib-metadata==8.4.0
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim AS builder
+FROM python:3.11.5-slim AS builder
 
 ADD . /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
-RUN pip install --target=/app requests
-RUN pip install --target=/app urllib3==2.2.2
-RUN pip install --target=/app importlib-metadata==8.4.0
+RUN pip install --target=/app requests==2.32.3 importlib-metadata==4.13.0
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.5-slim AS builder
+FROM python:3-slim AS builder
 
 ADD . /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
-RUN pip install --target=/app requests==2.32.3 importlib-metadata==4.13.0
+RUN pip install --target=/app requests==2.32.3 urllib3==2.2.2 importlib-metadata==4.13.0
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.11.5-slim-bullseye AS builder
-
-RUN pip install importlib-metadata
+FROM python:3.11.5-slim AS builder
 
 ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app requests
+RUN pip install --target=/app importlib-metadata
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app requests
 RUN pip install --target=/app urllib3==2.2.2
+RUN pip install --target=/app importlib-metadata==8.4.0
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
-RUN pip install --target=/app requests
-RUN pip install --target=/app importlib-metadata==8.4.0
+RUN pip3 install --target=/app requests
+#RUN pip install --target=/app importlib-metadata==8.4.0
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.5-slim AS builder
+FROM python:3.11.5-slim-bullseye AS builder
 
 RUN pip install importlib-metadata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
 RUN pip install --target=/app requests
-RUN pip install --target=/app importlib-metadata
+RUN pip install --target=/app urllib3==2.2.2
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.12.5-slim AS builder
+FROM python:3-slim AS builder
 
 ADD . /app
 WORKDIR /app
 
 # We are installing a dependency here directly into our app source dir
-RUN pip3 install --target=/app requests
-RUN pip3 install --target=/app importlib-metadata==8.4.0
+RUN pip install --target=/app requests
+RUN pip install --target=/app importlib-metadata
 
 # A distroless container image with Python and some basics like SSL certificates
 # https://github.com/GoogleContainerTools/distroless

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import importlib.metadata
+# import importlib.metadata
 import requests
 import time
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-# import importlib.metadata
+from importlib.metadata import version
 import requests
 import time
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from importlib.metadata import version
 import requests
 import time
 

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import importlib
 import requests
 import time
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-import importlib
+import importlib.metadata
 import requests
 import time
 


### PR DESCRIPTION
1. Specifies `python:3.11.5-slim` instead of `python:3-slim`
2. Specifies versions for `requests`, `urllib3`, and `importlib.metadata`
  a. `requests` depends on `urllib3`, whose recent release on Sep 12, 2024 might've caused our breaking change. I chose the previous version release.
  b. `urllib3` depends on `importlib.metadata`, whose recent release on Sep 11, 2024 might've caused our breaking change. Now that we're using Python 3.11.5, I chose the last release that contributed to 3.11's standard library.